### PR TITLE
Worker opts and bot cleanup

### DIFF
--- a/root/app/cleanup.sh
+++ b/root/app/cleanup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# killing existing workers before starting new ones
+echo "killing existing workers..."
+if [ -f "/tmp/diskover_bot_pids" ]; then
+    /bin/bash /app/diskover/diskover-bot-launcher.sh -k > /dev/null 2>&1
+    sleep 3
+fi
+
+# empty existing redis queue
+echo "emptying current redis queues..."
+rq empty -u redis://${DISKOVER_ARRAY[REDIS_HOST]}:${DISKOVER_ARRAY[REDIS_PORT]} diskover_crawl diskover diskover_calcdir failed
+sleep 3
+
+echo "killing dangling workers..."
+/bin/bash /app/diskover/diskover-bot-launcher.sh -k > /dev/null 2>&1
+sleep 3

--- a/root/app/dispatcher.sh
+++ b/root/app/dispatcher.sh
@@ -8,6 +8,7 @@ DISKOVER_ARRAY[TODAY]=$(date +%Y-%m-%d)
 DISKOVER_ARRAY[INDEX_PREFIX]=${INDEX_PREFIX:-diskover-}
 DISKOVER_ARRAY[INDEX_NAME]=${INDEX_NAME:-${DISKOVER_ARRAY[INDEX_PREFIX]}${DISKOVER_ARRAY[TODAY]}}
 DISKOVER_ARRAY[DISKOVER_OPTS]=${DISKOVER_OPTS:-"-d /data -a"}
+DISKOVER_ARRAY[WORKER_OPTS]=${WORKER_OPTS:-""}
 DISKOVER_ARRAY[REDIS_HOST]=${REDIS_HOST:-redis}
 DISKOVER_ARRAY[REDIS_PORT]=${REDIS_PORT:-6379}
 
@@ -15,21 +16,7 @@ DISKOVER_ARRAY[DISKOVER_OPTS]="${DISKOVER_ARRAY[DISKOVER_OPTS]} -i ${DISKOVER_AR
 
 cd /app/diskover || exit
 
-# killing existing workers before starting new ones
-echo "killing existing workers..."
-if [ -f "/tmp/diskover_bot_pids" ]; then
-    /bin/bash /app/diskover/diskover-bot-launcher.sh -k > /dev/null 2>&1
-    sleep 3
-fi
-
-# empty existing redis queue
-echo "emptying current redis queues..."
-rq empty -u redis://${DISKOVER_ARRAY[REDIS_HOST]}:${DISKOVER_ARRAY[REDIS_PORT]} diskover_crawl diskover diskover_calcdir failed
-sleep 3
-
-echo "killing dangling workers..."
-/bin/bash /app/diskover/diskover-bot-launcher.sh -k > /dev/null 2>&1
-sleep 3
+/bin/bash /app/cleanup.sh
 
 echo "starting workers with following options: ${DISKOVER_ARRAY[WORKER_OPTS]}"
 /bin/bash /app/diskover/diskover-bot-launcher.sh ${DISKOVER_ARRAY[WORKER_OPTS]}

--- a/root/etc/services.d/rq-dashboard/run
+++ b/root/etc/services.d/rq-dashboard/run
@@ -1,5 +1,13 @@
 #!/usr/bin/with-contenv bash
 
+# need to safely handle exiting the existing worker bots and
+# redis queue when container restarts or stops
+_term() {
+	/bin/bash /app/cleanup.sh
+}
+
+trap _term SIGTERM
+
 declare -A REDIS_CONF
 REDIS_CONF[REDIS_HOST]=${REDIS_HOST:-redis}
 REDIS_CONF[REDIS_PORT]=${REDIS_PORT:-6379}


### PR DESCRIPTION
This solves 2 issues:

1. worker bot / redis queue was not cleaned up / killed on a container stop / restart
2. now honoring missing `WORKER_OPTS` variable

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

