### PR TITLE
rebasing to alpine 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:3.8
+FROM lsiobase/nginx:3.9
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm64v8-3.8
+FROM lsiobase/nginx:arm64v8-3.9
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/nginx:arm32v7-3.8
+FROM lsiobase/nginx:arm32v7-3.9
 
 # set version label
 ARG BUILD_DATE

--- a/README.md
+++ b/README.md
@@ -228,5 +228,6 @@ Below are the instructions for updating containers:
 
 ## Versions
 
+* **12.04.19:** - Rebase to Alpine 3.9.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **01.11.18:** - Initial Release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -107,5 +107,6 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "12.04.19:", desc: "Rebase to Alpine 3.9." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "01.11.18:", desc: "Initial Release." }


### PR DESCRIPTION
This was leftover from the Alpine 3.9 rebase as there was an upstream bug in Python3 on arm64:
https://bugs.alpinelinux.org/issues/9981