### PR TITLE
Export DISKOVER_ARRAY for cleanup.sh

### DIFF
--- a/root/app/cleanup.sh
+++ b/root/app/cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bash
 
 # killing existing workers before starting new ones
 echo "killing existing workers..."

--- a/root/app/dispatcher.sh
+++ b/root/app/dispatcher.sh
@@ -16,7 +16,7 @@ DISKOVER_ARRAY[DISKOVER_OPTS]="${DISKOVER_ARRAY[DISKOVER_OPTS]} -i ${DISKOVER_AR
 
 cd /app/diskover || exit
 
-BASH_ENV=<(declare -p DISKOVER_ARRAY) /bin/bash /app/cleanup.sh
+/bin/bash /app/cleanup.sh
 
 echo "starting workers with following options: ${DISKOVER_ARRAY[WORKER_OPTS]}"
 /bin/bash /app/diskover/diskover-bot-launcher.sh ${DISKOVER_ARRAY[WORKER_OPTS]}

--- a/root/app/dispatcher.sh
+++ b/root/app/dispatcher.sh
@@ -16,7 +16,7 @@ DISKOVER_ARRAY[DISKOVER_OPTS]="${DISKOVER_ARRAY[DISKOVER_OPTS]} -i ${DISKOVER_AR
 
 cd /app/diskover || exit
 
-/bin/bash /app/cleanup.sh
+BASH_ENV=<(declare -p DISKOVER_ARRAY) /bin/bash /app/cleanup.sh
 
 echo "starting workers with following options: ${DISKOVER_ARRAY[WORKER_OPTS]}"
 /bin/bash /app/diskover/diskover-bot-launcher.sh ${DISKOVER_ARRAY[WORKER_OPTS]}


### PR DESCRIPTION
Hi,

I get the following Redis errors from the dispatch script:

```
+ cd /app/diskover
+ /bin/bash -x /app/cleanup.sh
+ echo 'killing existing workers...'
killing existing workers...
+ '[' -f /tmp/diskover_bot_pids ']'
+ /bin/bash /app/diskover/diskover-bot-launcher.sh -k
+ sleep 3
+ echo 'emptying current redis queues...'
emptying current redis queues...
+ rq empty -u redis://: diskover_crawl diskover diskover_calcdir failed
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/redis/connection.py", line 493, in connect
    sock = self._connect()
  File "/usr/lib/python3.6/site-packages/redis/connection.py", line 550, in _connect
    raise err
  File "/usr/lib/python3.6/site-packages/redis/connection.py", line 538, in _connect
    sock.connect(socket_address)
OSError: [Errno 101] Network unreachable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/redis/client.py", line 754, in execute_command
    connection.send_command(*args)
  File "/usr/lib/python3.6/site-packages/redis/connection.py", line 619, in send_command
    self.send_packed_command(self.pack_command(*args))
  File "/usr/lib/python3.6/site-packages/redis/connection.py", line 594, in send_packed_command
    self.connect()
  File "/usr/lib/python3.6/site-packages/redis/connection.py", line 498, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error 101 connecting to None:6379. Network unreachable.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/redis/connection.py", line 493, in connect
    sock = self._connect()
  File "/usr/lib/python3.6/site-packages/redis/connection.py", line 550, in _connect
    raise err
  File "/usr/lib/python3.6/site-packages/redis/connection.py", line 538, in _connect
    sock.connect(socket_address)
OSError: [Errno 101] Network unreachable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/rq", line 11, in <module>
    sys.exit(main())
  File "/usr/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/rq/cli/cli.py", line 76, in wrapper
    return ctx.invoke(func, cli_config, *args[1:], **kwargs)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/rq/cli/cli.py", line 109, in empty
    num_jobs = queue.empty()
  File "/usr/lib/python3.6/site-packages/rq/queue.py", line 117, in empty
    return script(keys=[self.key])
  File "/usr/lib/python3.6/site-packages/redis/client.py", line 3498, in __call__
    return client.evalsha(self.sha, len(keys), *args)
  File "/usr/lib/python3.6/site-packages/redis/client.py", line 2704, in evalsha
    return self.execute_command('EVALSHA', sha, numkeys, *keys_and_args)
  File "/usr/lib/python3.6/site-packages/redis/client.py", line 760, in execute_command
    connection.send_command(*args)
  File "/usr/lib/python3.6/site-packages/redis/connection.py", line 619, in send_command
    self.send_packed_command(self.pack_command(*args))
  File "/usr/lib/python3.6/site-packages/redis/connection.py", line 594, in send_packed_command
    self.connect()
  File "/usr/lib/python3.6/site-packages/redis/connection.py", line 498, in connect
    raise ConnectionError(self._error_message(e))
redis.exceptions.ConnectionError: Error 101 connecting to None:6379. Network unreachable.
```

This seems to be because `DISKOVER_ARRAY` is not exported so that it can be read from the child `cleanup.sh` script. From https://stackoverflow.com/questions/5564418/exporting-an-array-in-bash-script, it appears to be possible to do this with the following change, and all works.

Looking forward to your feedback

Thanks