### PR TITLE
default.conf fastcgi fix

### DIFF
--- a/root/defaults/nginx/site-confs/default.conf.sample
+++ b/root/defaults/nginx/site-confs/default.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/04/13 - Changelog: https://github.com/linuxserver/docker-diskover/commits/master/root/defaults/nginx/site-confs/default.conf.sample
+## Version 2023/08/29 - Changelog: https://github.com/linuxserver/docker-diskover/commits/master/root/defaults/nginx/site-confs/default.conf.sample
 
 server {
     listen 80 default_server;


### PR DESCRIPTION
resolves https://github.com/diskoverdata/diskover-community/issues/101

resolves discord thread: https://discord.com/channels/354974912613449730/1143304082350686299
and discourse thread: https://discourse.linuxserver.io/t/diskover-white-page-on-login/7987 which is a dupe of discord thread: https://discord.com/channels/354974912613449730/1145143386890829824